### PR TITLE
feat: add handling for NOTIFICATION_ERROR transaction state

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Here a description of when expiration event is sent based on the transaction sta
 | CLOSURE_ERROR           | ✅                     |
 | CLOSED                  | ✅                     |
 | NOTIFIED_KO             | ✅                     |
+| NOTIFICATION_ERROR      | ✅                     |
 | EXPIRED_NOT_AUTHORIZED  | ❌                     |
 | CANCELED                | ❌                     |
 | UNAUTHORIZED            | ❌                     |

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <java.version>17</java.version>
         <azure.functions.java.library.version>3.0.0</azure.functions.java.library.version>
         <spring.cloud.azure.dependencies>4.0.0</spring.cloud.azure.dependencies>
-        <pagopa-ecommerce-commons.version>0.8.7</pagopa-ecommerce-commons.version>
+        <pagopa-ecommerce-commons.version>0.8.8</pagopa-ecommerce-commons.version>
         <spotless.version>2.28.0</spotless.version>
         <jacoco.version>0.8.8</jacoco.version>
         <maven.compiler.plugin.version>3.10.1</maven.compiler.plugin.version>

--- a/src/main/kotlin/it/pagopa/ecommerce/transactions/scheduler/transactionanalyzer/PendingTransactionAnalyzer.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/transactions/scheduler/transactionanalyzer/PendingTransactionAnalyzer.kt
@@ -34,7 +34,7 @@ class PendingTransactionAnalyzer(
             TransactionStatusDto.REFUND_REQUESTED,
             TransactionStatusDto.REFUND_ERROR,
             TransactionStatusDto.REFUNDED,
-            TransactionStatusDto.CANCELLATION_EXPIRED
+            TransactionStatusDto.CANCELLATION_EXPIRED,
         ),
     /*
      * Set of all transaction statuses for which send expiry event
@@ -47,7 +47,8 @@ class PendingTransactionAnalyzer(
             TransactionStatusDto.CANCELLATION_REQUESTED,
             TransactionStatusDto.CLOSURE_ERROR,
             TransactionStatusDto.CLOSED,
-            TransactionStatusDto.NOTIFIED_KO
+            TransactionStatusDto.NOTIFIED_KO,
+            TransactionStatusDto.NOTIFICATION_ERROR,
         )
 ) {
 

--- a/src/test/kotlin/it/pagopa/ecommerce/transactions/scheduler/transactionanalyzer/PendingTransactionAnalyzerTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/transactions/scheduler/transactionanalyzer/PendingTransactionAnalyzerTests.kt
@@ -177,6 +177,42 @@ class PendingTransactionAnalyzerTests {
     }
 
     @Test
+    fun `Should send event for pending transaction in NOTIFICATION_ERROR user receipt OK state`() {
+        // assertions
+        val events =
+            listOf(
+                TransactionTestUtils.transactionActivateEvent(),
+                TransactionTestUtils.transactionAuthorizationRequestedEvent(),
+                TransactionTestUtils.transactionAuthorizationCompletedEvent(),
+                TransactionTestUtils.transactionClosedEvent(TransactionClosureData.Outcome.OK),
+                TransactionTestUtils.transactionUserReceiptAddErrorEvent(
+                    TransactionUserReceiptData.Outcome.OK
+                )
+            )
+                as List<TransactionEvent<Any>>
+
+        checkThatExpiryEventIsSent(events, TransactionStatusDto.NOTIFICATION_ERROR)
+    }
+
+    @Test
+    fun `Should send event for pending transaction in NOTIFICATION_ERROR user receipt KO state`() {
+        // assertions
+        val events =
+            listOf(
+                TransactionTestUtils.transactionActivateEvent(),
+                TransactionTestUtils.transactionAuthorizationRequestedEvent(),
+                TransactionTestUtils.transactionAuthorizationCompletedEvent(),
+                TransactionTestUtils.transactionClosedEvent(TransactionClosureData.Outcome.OK),
+                TransactionTestUtils.transactionUserReceiptAddErrorEvent(
+                    TransactionUserReceiptData.Outcome.KO
+                )
+            )
+                as List<TransactionEvent<Any>>
+
+        checkThatExpiryEventIsSent(events, TransactionStatusDto.NOTIFICATION_ERROR)
+    }
+
+    @Test
     fun `Should not send event for pending transaction in EXPIRED_NOT_AUTHORIZED state`() {
         // assertions
         val events =


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Update commons to version 0.8.8
This version included the new state `NOTIFICATION_ERROR`.
Add this state to the ones for which send expiration event for all transactions found in that state
<!--- Describe your changes in detail -->

#### Motivation and Context
Those modifications are needed in order to handle `NOTIFICATION_ERROR` transaction status
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Junit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
