### PR TITLE
fix: handle expired not authorized status

### DIFF
--- a/src/main/kotlin/it/pagopa/ecommerce/transactions/scheduler/publishers/EventPublisher.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/transactions/scheduler/publishers/EventPublisher.kt
@@ -58,11 +58,10 @@ abstract class EventPublisher<E>(
         newStatus: TransactionStatusDto
     ): Mono<E>
 
-    abstract fun toEvent(baseTrasaction: BaseTransaction): Mono<E>
+    abstract fun toEvent(baseTransaction: BaseTransaction): Mono<E>
 
     protected fun publishAllEvents(
-        transactions: List<BaseTransaction>,
-        newStatus: TransactionStatusDto,
+        transactions: List<Pair<BaseTransaction, TransactionStatusDto>>,
         batchExecutionWindowMillis: Long
     ): Mono<Boolean> {
         val eventOffset = AtomicLong(0L)
@@ -70,7 +69,7 @@ abstract class EventPublisher<E>(
         return Flux.fromIterable(transactions)
             .parallel(parallelEventsToProcess)
             .runOn(Schedulers.parallel())
-            .flatMap { publishEvent(it, newStatus, eventOffset.addAndGet(offsetIncrement)) }
+            .flatMap { publishEvent(it.first, it.second, eventOffset.addAndGet(offsetIncrement)) }
             .sequential()
             .collectList()
             .map { it.none { eventSent -> !eventSent } }

--- a/src/main/kotlin/it/pagopa/ecommerce/transactions/scheduler/publishers/EventPublisher.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/transactions/scheduler/publishers/EventPublisher.kt
@@ -69,7 +69,9 @@ abstract class EventPublisher<E>(
         return Flux.fromIterable(transactions)
             .parallel(parallelEventsToProcess)
             .runOn(Schedulers.parallel())
-            .flatMap { publishEvent(it.first, it.second, eventOffset.addAndGet(offsetIncrement)) }
+            .flatMap { (transaction, status) ->
+                publishEvent(transaction, status, eventOffset.addAndGet(offsetIncrement))
+            }
             .sequential()
             .collectList()
             .map { it.none { eventSent -> !eventSent } }

--- a/src/main/kotlin/it/pagopa/ecommerce/transactions/scheduler/publishers/TransactionExpiredEventPublisher.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/transactions/scheduler/publishers/TransactionExpiredEventPublisher.kt
@@ -8,7 +8,6 @@ import it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto
 import it.pagopa.ecommerce.transactions.scheduler.repositories.TransactionsEventStoreRepository
 import it.pagopa.ecommerce.transactions.scheduler.repositories.TransactionsViewRepository
 import java.util.logging.Logger
-import java.util.stream.Collectors
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
@@ -36,12 +35,8 @@ class TransactionExpiredEventPublisher(
     ): Mono<Boolean> {
         // split expired transaction in two lists: one for transactions without requested
         // authorization and one with requested authorization
-        val splittedTransactions: Map<Boolean, List<BaseTransaction>> =
-            baseTransactions
-                .stream()
-                .collect(Collectors.groupingBy { it is BaseTransactionWithRequestedAuthorization })
-        val baseTransactionsWithRequestedAuthorization = splittedTransactions[true] ?: emptyList()
-        val baseTransactionsActivatedOnly = splittedTransactions[false] ?: emptyList()
+        val (baseTransactionsWithRequestedAuthorization, baseTransactionsActivatedOnly) =
+            baseTransactions.partition { it is BaseTransactionWithRequestedAuthorization }
         val mergedTransactions =
             baseTransactionsWithRequestedAuthorization
                 .map { Pair(it, TransactionStatusDto.EXPIRED) }

--- a/src/main/kotlin/it/pagopa/ecommerce/transactions/scheduler/transactionanalyzer/PendingTransactionAnalyzer.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/transactions/scheduler/transactionanalyzer/PendingTransactionAnalyzer.kt
@@ -69,12 +69,12 @@ class PendingTransactionAnalyzer(
                 analyzeTransaction(it.transactionId)
             }
             .collectList()
-            .flatMap {
-                if (it.isEmpty()) {
+            .flatMap { expiredTransactions ->
+                if (expiredTransactions.isEmpty()) {
                     Mono.just(true)
                 } else {
                     expiredTransactionEventPublisher.publishExpiryEvents(
-                        it,
+                        expiredTransactions,
                         batchExecutionIntertime
                     )
                 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Add logic to distinguish status for the status on which update the expired transaction.
Before this modification all transaction was updated to `EXPIRED` status.
This modification check for each transaction if authorization was requested and then set expiration status to EXPIRED or EXPIRED_NOT_AUTHORIZED according to the fact that the authorization was requested or not
<!--- Describe your changes in detail -->

#### Motivation and Context
This modification is needed in order to update transaction status correctly to EXPIRED or EXPIRED_NOT_AUTHORIZED
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Junit test + test with ecommerce local
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
