### PR TITLE
fix: handle expiration status for transaction in closure error

### DIFF
--- a/src/main/kotlin/it/pagopa/ecommerce/transactions/scheduler/publishers/TransactionExpiredEventPublisher.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/transactions/scheduler/publishers/TransactionExpiredEventPublisher.kt
@@ -38,7 +38,13 @@ class TransactionExpiredEventPublisher(
         // split expired transaction in two lists: one for transactions without requested
         // authorization and one with requested authorization
         val (baseTransactionsWithRequestedAuthorization, baseTransactionsNotActivated) =
-            baseTransactions.partition { it is BaseTransactionWithRequestedAuthorization }
+            baseTransactions.partition {
+                it is BaseTransactionWithRequestedAuthorization ||
+                    it is TransactionWithClosureError &&
+                        it.transactionAtPreviousState()
+                            .map { txAtPrevStep -> txAtPrevStep.isRight }
+                            .orElse(false)
+            }
         // taking transaction for which no authorization was performed another split is done between
         // transactions with canceled by user and not
         val (baseTransactionUserCanceled, baseTransactionActivatedOnly) =

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,4 +8,3 @@ azurestorage.queues.transactionexpired.name=${TRANSACTION_EXPIRED_EVENTS_QUEUE_N
 pendingTransactions.batch.scheduledChron=${PENDING_TRANSACTIONS_SCHEDULE_CRON}
 pendingTransactions.batch.transactionsAnalyzer.executionRateMultiplier=${PENDING_TRANSACTIONS_WINDOWS_BATCH_EXECUTION_RATE_MULTIPLIER}
 pendingTransactions.batch.transactionsAnalyzer.parallelEventsToProcess=${PENDING_TRANSACTIONS_PARALLEL_EVENTS_TO_PROCESS}
-server.port=9999

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,3 +8,4 @@ azurestorage.queues.transactionexpired.name=${TRANSACTION_EXPIRED_EVENTS_QUEUE_N
 pendingTransactions.batch.scheduledChron=${PENDING_TRANSACTIONS_SCHEDULE_CRON}
 pendingTransactions.batch.transactionsAnalyzer.executionRateMultiplier=${PENDING_TRANSACTIONS_WINDOWS_BATCH_EXECUTION_RATE_MULTIPLIER}
 pendingTransactions.batch.transactionsAnalyzer.parallelEventsToProcess=${PENDING_TRANSACTIONS_PARALLEL_EVENTS_TO_PROCESS}
+server.port=9999


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Handle expiration status for transactions in closure error status checking if they belongs to user cancelled flow or transaction authorized ones.
For transaction in `CLOSURE_ERROR` status that belong to authorized flow expiration status is set to `EXPIRED`
<!--- Describe your changes in detail -->

#### Motivation and Context
This modification fixes status update for transactions stuck in CLOSURE_ERROR status for which transaction has expired updating status to EXPIRED
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Junit test + local test with ecommerce commons
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
