### PR TITLE
fix: add max duration for batch execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ timeout inter-time of 12 minutes, so:
 
 This mechanism prevents the module that read those events to be flooded in case of too many events to send.
 
+### Transactions to analyze time window
+
 Once started the batch analyze all transactions in a given time windows calculated from the batch execution rate and the
 value of the `PENDING_TRANSACTIONS_WINDOWS_BATCH_EXECUTION_RATE_MULTIPLIER` parameter.
 
@@ -68,15 +70,32 @@ the previous time slot.
 
 ---
 
+## Configuration
+
+### Environment variables
+
+These are all environment variables needed by the application:
+
+| Variable name                                                | Description                                                                                                                                                                                                                                                                  | type    | default |
+|--------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|---------|
+| MONGO_HOST                                                   | Mongo hostname                                                                                                                                                                                                                                                               | string  |         |
+| MONGO_USERNAME                                               | Mongo username                                                                                                                                                                                                                                                               | string  |         |
+| MONGO_PORT                                                   | Mongo port                                                                                                                                                                                                                                                                   | int     |         |
+| MONGO_SSL_ENABLED                                            | Mongo SSL enabled                                                                                                                                                                                                                                                            | boolean |         |
+| ECOMMERCE_DATABASE_NAME                                      | Mongo ecommerce database name                                                                                                                                                                                                                                                | string  |         |
+| TRANSACTION_EXPIRED_EVENTS_QUEUE_NAME                        | Transaction expired event queue name. This is the queue where transaction expired events will be sent                                                                                                                                                                        | string  |         |
+| PENDING_TRANSACTIONS_SCHEDULE_CRON                           | Pending transactions batch execution chron expression                                                                                                                                                                                                                        | string  |         |
+| PENDING_TRANSACTIONS_WINDOWS_BATCH_EXECUTION_RATE_MULTIPLIER | Pending transactions execution rate multiplier (used for calculate transactions window, see [Transactions to analyze time window](#Transactions-to-analyze-time-window)                                                                                                      | int     |         |
+| PENDING_TRANSACTIONS_PARALLEL_EVENTS_TO_PROCESS              | Pending transactions parallel events to be processed                                                                                                                                                                                                                         | int     |         |
+| PENDING_TRANSACTIONS_MAX_DURATION_SECONDS                    | Single batch max duration in seconds. Indicate the max time to wait for a single batch iteration to be completed. If negative the execution-rate-inter-time/2 will be used (Ex: if batch is configured to be executed every 10 minutes max duration will be set to 5 minutes | int     | -1      |
+
+---
+
 ## Run locally with Docker
 
 `docker build -t pagopa-ecommerce-transactions-scheduler-service .`
 
-`docker run -p 8999:80 pagopa-ecommerce-transactions-scheduler-service`
-
-### Test
-
-`curl http://localhost:8999/example`
+`docker run -p 8999:8080 pagopa-ecommerce-transactions-scheduler-service`
 
 ## Run locally with Maven
 
@@ -84,7 +103,7 @@ the previous time slot.
 
 `mvn clean spring-boot:run` build and run service with spring locally
 
-For testing purpose the commons reference can be change from a specific release to a branch by changing the following
+For testing purpose the commons reference can be changed from a specific release to a branch by changing the following
 configurations tags inside `pom.xml`:
 
 FROM:

--- a/src/main/kotlin/it/pagopa/ecommerce/transactions/scheduler/scheduledperations/PendingTransactionBatch.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/transactions/scheduler/scheduledperations/PendingTransactionBatch.kt
@@ -61,7 +61,7 @@ class PendingTransactionBatch(
             } else {
                 /*
                  * Batch max duration set to batch execution interleave divided by 2.
-                 * The only constraint here is that the batch max execution time is lesser than
+                 * The only constraint here is that the batch max execution time is less than
                  * the batch execution interleave in order to avoid one execution to be skipped
                  * because of the previous batch execution still running
                  */

--- a/src/main/kotlin/it/pagopa/ecommerce/transactions/scheduler/scheduledperations/PendingTransactionBatch.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/transactions/scheduler/scheduledperations/PendingTransactionBatch.kt
@@ -53,10 +53,7 @@ class PendingTransactionBatch(
                 )
                 isOk = true
             }
-            .onFailure {
-                logger.error("Error executing batch", it)
-                // throw it
-            }
+            .onFailure { logger.error("Error executing batch", it) }
         return isOk
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,3 +10,4 @@ azurestorage.queues.transactionexpired.name=${TRANSACTION_EXPIRED_EVENTS_QUEUE_N
 pendingTransactions.batch.scheduledChron=${PENDING_TRANSACTIONS_SCHEDULE_CRON}
 pendingTransactions.batch.transactionsAnalyzer.executionRateMultiplier=${PENDING_TRANSACTIONS_WINDOWS_BATCH_EXECUTION_RATE_MULTIPLIER}
 pendingTransactions.batch.transactionsAnalyzer.parallelEventsToProcess=${PENDING_TRANSACTIONS_PARALLEL_EVENTS_TO_PROCESS}
+pendingTransactions.batch.maxDurationSeconds=${PENDING_TRANSACTIONS_MAX_DURATION_SECONDS:-1}

--- a/src/test/kotlin/it/pagopa/ecommerce/transactions/scheduler/scheduledperations/PendingTransactionBatchTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/transactions/scheduler/scheduledperations/PendingTransactionBatchTests.kt
@@ -136,6 +136,6 @@ class PendingTransactionBatchTests {
                 }
                 .toJavaDuration()
         assertTrue(duration < pendingTransactionBatchTaskDuration)
-        assertTrue(duration.seconds.toInt() == pendingTransactionBatch.batchMaxDurationSeconds)
+        assertEquals(pendingTransactionBatch.batchMaxDurationSeconds, duration.seconds.toInt())
     }
 }

--- a/src/test/kotlin/it/pagopa/ecommerce/transactions/scheduler/scheduledperations/PendingTransactionBatchTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/transactions/scheduler/scheduledperations/PendingTransactionBatchTests.kt
@@ -9,6 +9,7 @@ import kotlin.time.ExperimentalTime
 import kotlin.time.measureTime
 import kotlin.time.toJavaDuration
 import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito

--- a/src/test/kotlin/it/pagopa/ecommerce/transactions/scheduler/scheduledperations/PendingTransactionBatchTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/transactions/scheduler/scheduledperations/PendingTransactionBatchTests.kt
@@ -4,17 +4,24 @@ import it.pagopa.ecommerce.transactions.scheduler.transactionanalyzer.PendingTra
 import java.time.Duration
 import java.time.temporal.ChronoUnit
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+import kotlin.time.ExperimentalTime
+import kotlin.time.measureTime
+import kotlin.time.toJavaDuration
 import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
+import org.mockito.kotlin.given
 import org.springframework.test.context.TestPropertySource
 import reactor.core.publisher.Mono
 
 @ExtendWith(MockitoExtension::class)
 @TestPropertySource(locations = ["classpath:application-tests.properties"])
+@OptIn(ExperimentalTime::class)
 class PendingTransactionBatchTests {
 
     @Mock private lateinit var pendingTransactionAnalyzer: PendingTransactionAnalyzer
@@ -88,5 +95,47 @@ class PendingTransactionBatchTests {
             interTimeExecutionDuration.toMillis() / 2,
             calculatedMaxDuration.toMillis()
         )
+    }
+
+    @Test
+    fun `Should handle batch execution error without throwing exception`() {
+        // assertions
+        BDDMockito.given(pendingTransactionAnalyzer.searchPendingTransactions(any(), any(), any()))
+            .willReturn(Mono.error(RuntimeException("Error executing batch")))
+        assertDoesNotThrow { pendingTransactionBatch.execute() }
+    }
+
+    @Test
+    fun `Should handle batch execution that takes longer than max duration configured`() {
+        // assertions
+        val pendingTransactionBatch =
+            PendingTransactionBatch(
+                pendingTransactionAnalyzer = pendingTransactionAnalyzer,
+                chronExpression = cronExecutionString,
+                executionRateMultiplier = executionRateMultiplier,
+                batchMaxDurationSeconds = 1
+            )
+        val maxExecutionTime =
+            pendingTransactionBatch.getMaxDuration(
+                pendingTransactionBatch.getExecutionsInterleaveTimeMillis(
+                    pendingTransactionBatch.chronExpression
+                ),
+                pendingTransactionBatch.batchMaxDurationSeconds
+            )
+        val pendingTransactionBatchTaskDuration = maxExecutionTime.multipliedBy(100)
+        given { pendingTransactionAnalyzer.searchPendingTransactions(any(), any(), any()) }
+            .willReturn(Mono.just(true).delayElement(pendingTransactionBatchTaskDuration))
+
+        val duration =
+            measureTime {
+                    val exception =
+                        assertThrows<Exception> {
+                            pendingTransactionBatch.pendingTransactionAnalyzerPipeline().block()
+                        }
+                    assertTrue(exception.cause is TimeoutException)
+                }
+                .toJavaDuration()
+        assertTrue(duration < pendingTransactionBatchTaskDuration)
+        assertTrue(duration.seconds.toInt() == pendingTransactionBatch.batchMaxDurationSeconds)
     }
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Add logic to set max time to be wait for a single batch run to be executed.
The single batch max execution time is parametrized with `PENDING_TRANSACTIONS_MAX_DURATION_SECONDS` variable with a default of -1.
If the above variable is valued then that value is used as batch max duration time, otherwise the max duration is calculated as half of batch executions inter time. 
Given a batch execution chron of 1 hour (1 execution at the beginnig of every hour), the executions intertime will be of one hour and the batch max execution time will be set to be half hour
<!--- Describe your changes in detail -->

#### Motivation and Context
Those modifications are needed because as for now execution will block indeterminately causing subsequent execution to be not executed if the previous execution is still running
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Local tests and junit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
