### PR TITLE
fix: explicitate eventstore reduce orderby creation date

### DIFF
--- a/src/main/kotlin/it/pagopa/ecommerce/transactions/scheduler/repositories/TransactionsEventStoreRepository.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/transactions/scheduler/repositories/TransactionsEventStoreRepository.kt
@@ -8,5 +8,5 @@ import reactor.core.publisher.Flux
 @Repository
 interface TransactionsEventStoreRepository<T> :
     ReactiveCrudRepository<TransactionEvent<T>, String> {
-    fun findByTransactionId(idTransaction: String): Flux<TransactionEvent<T>>
+    fun findByTransactionIdOrderByCreationDateAsc(idTransaction: String): Flux<TransactionEvent<T>>
 }

--- a/src/main/kotlin/it/pagopa/ecommerce/transactions/scheduler/transactionanalyzer/PendingTransactionAnalyzer.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/transactions/scheduler/transactionanalyzer/PendingTransactionAnalyzer.kt
@@ -83,7 +83,7 @@ class PendingTransactionAnalyzer(
 
     private fun analyzeTransaction(transactionId: String): Mono<BaseTransaction> {
         return eventStoreRepository
-            .findByTransactionId(transactionId)
+            .findByTransactionIdOrderByCreationDateAsc(transactionId)
             .reduce(
                 EmptyTransaction(),
                 it.pagopa.ecommerce.commons.domain.v1.Transaction::applyEvent

--- a/src/test/kotlin/it/pagopa/ecommerce/transactions/scheduler/transactionanalyzer/PendingTransactionAnalyzerTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/transactions/scheduler/transactionanalyzer/PendingTransactionAnalyzerTests.kt
@@ -522,7 +522,7 @@ class PendingTransactionAnalyzerTests {
             .willAnswer { transactionStatusesForSendExpiryEventOriginal.contains(it.arguments[0]) }
         given(viewRepository.findTransactionInTimeRangeWithExcludedStatuses(any(), any(), any()))
             .willReturn(Flux.just(*transactions.toTypedArray()))
-        given(eventStoreRepository.findByTransactionId(any()))
+        given(eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(any()))
             .willReturn(Flux.just(*events.toTypedArray()))
         given(transactionExpiredEventPublisher.publishExpiryEvents(any(), any()))
             .willReturn(Mono.just(true))
@@ -570,7 +570,7 @@ class PendingTransactionAnalyzerTests {
             .willAnswer { transactionStatusesForSendExpiryEventOriginal.contains(it.arguments[0]) }
         given(viewRepository.findTransactionInTimeRangeWithExcludedStatuses(any(), any(), any()))
             .willReturn(Flux.just(*transactions.toTypedArray()))
-        given(eventStoreRepository.findByTransactionId(any()))
+        given(eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(any()))
             .willReturn(Flux.just(*events.toTypedArray()))
         // test
         StepVerifier.create(


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Explicitate orderBy creation date ascending for query used to retrieve events related to a transaction
<!--- Describe your changes in detail -->

#### Motivation and Context
This modification is needed in order to explicitate creation date ordering when retrieving transaction event
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Local test with ecommerce local performing a transaction flow up to the authorization request PATCH checking that transaction events are correctly reduced
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.