### PR TITLE
[PPABV-47] feat: add paymentEndToEndId into DeadLetterNpgTransactionInfoDetailsData

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <java.version>17</java.version>
         <azure.functions.java.library.version>3.0.0</azure.functions.java.library.version>
         <spring.cloud.azure.dependencies>4.0.0</spring.cloud.azure.dependencies>
-        <pagopa-ecommerce-commons.version>1.25.0</pagopa-ecommerce-commons.version>
+        <pagopa-ecommerce-commons.version>1.29.0</pagopa-ecommerce-commons.version>
         <spotless.version>2.28.0</spotless.version>
         <jacoco.version>0.8.8</jacoco.version>
         <maven.compiler.plugin.version>3.10.1</maven.compiler.plugin.version>

--- a/src/main/kotlin/it/pagopa/ecommerce/transactions/scheduler/services/TransactionInfoService.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/transactions/scheduler/services/TransactionInfoService.kt
@@ -211,7 +211,8 @@ class TransactionInfoService(
                                     DeadLetterNpgTransactionInfoDetailsData(
                                         it.authorization.operationResult,
                                         it.authorization.operationId,
-                                        correlationId
+                                        correlationId,
+                                        it.authorization.paymentEndToEndId
                                     )
                                 )
                             is NgpOrderNotAuthorized ->
@@ -219,7 +220,8 @@ class TransactionInfoService(
                                     DeadLetterNpgTransactionInfoDetailsData(
                                         it.operation.operationResult,
                                         it.operation.operationId,
-                                        correlationId
+                                        correlationId,
+                                        it.operation.paymentEndToEndId
                                     )
                                 )
                             is NpgOrderRefunded ->
@@ -227,7 +229,8 @@ class TransactionInfoService(
                                     DeadLetterNpgTransactionInfoDetailsData(
                                         it.refundOperation.operationResult,
                                         it.refundOperation.operationId,
-                                        correlationId
+                                        correlationId,
+                                        it.refundOperation.paymentEndToEndId
                                     )
                                 )
                             else ->

--- a/src/test/kotlin/it/pagopa/ecommerce/transactions/scheduler/TransactionSchedulerTestUtil.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/transactions/scheduler/TransactionSchedulerTestUtil.kt
@@ -23,7 +23,8 @@ object TransactionSchedulerTestUtil {
             DeadLetterNpgTransactionInfoDetailsData(
                 OperationResultDto.EXECUTED,
                 "id",
-                UUID.randomUUID().toString()
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(),
             )
         )
 

--- a/src/test/kotlin/it/pagopa/ecommerce/transactions/scheduler/services/TransactionInfoServiceTest.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/transactions/scheduler/services/TransactionInfoServiceTest.kt
@@ -44,6 +44,8 @@ class TransactionInfoServiceTest {
 
     companion object {
         private val correlationId = UUID.randomUUID().toString()
+        private val paymentEndToEndId = "paymentEndToEndId"
+        private val operationId = "operationId"
 
         @JvmStatic
         private fun retriverArgsTest() =
@@ -53,8 +55,9 @@ class TransactionInfoServiceTest {
                     buildOrderResponseDtoForNgpOrderNotAuthorized(),
                     DeadLetterNpgTransactionInfoDetailsData(
                         OperationResultDto.FAILED,
-                        "operationId",
-                        correlationId
+                        operationId,
+                        correlationId,
+                        paymentEndToEndId
                     )
                 ),
                 Arguments.of(
@@ -62,8 +65,9 @@ class TransactionInfoServiceTest {
                     buildOrderResponseDtoForNgpOrderAuthorized(),
                     DeadLetterNpgTransactionInfoDetailsData(
                         OperationResultDto.EXECUTED,
-                        "operationId",
-                        correlationId
+                        operationId,
+                        correlationId,
+                        paymentEndToEndId
                     )
                 ),
                 Arguments.of(
@@ -71,8 +75,9 @@ class TransactionInfoServiceTest {
                     buildOrderResponseDtoForNpgOrderRefunded(),
                     DeadLetterNpgTransactionInfoDetailsData(
                         OperationResultDto.VOIDED,
-                        "operationId",
-                        correlationId
+                        operationId,
+                        correlationId,
+                        paymentEndToEndId
                     )
                 ),
                 Arguments.of(
@@ -125,9 +130,7 @@ class TransactionInfoServiceTest {
         val transactionUserReceiptData =
             transactionUserReceiptData(TransactionUserReceiptData.Outcome.OK)
         val transactionActivatedEvent =
-            transactionActivateEvent(
-                NpgTransactionGatewayActivationData("orderId", correlationId.toString())
-            )
+            transactionActivateEvent(NpgTransactionGatewayActivationData("orderId", correlationId))
         val authorizationRequestedEvent =
             transactionAuthorizationRequestedEvent(
                 TransactionAuthorizationRequestData.PaymentGateway.NPG
@@ -153,8 +156,9 @@ class TransactionInfoServiceTest {
                 baseTransaction,
                 DeadLetterNpgTransactionInfoDetailsData(
                     OperationResultDto.VOIDED,
-                    "operationId",
-                    correlationId
+                    operationId,
+                    correlationId,
+                    paymentEndToEndId
                 )
             )
 
@@ -191,8 +195,9 @@ class TransactionInfoServiceTest {
                 baseTransaction,
                 DeadLetterNpgTransactionInfoDetailsData(
                     OperationResultDto.VOIDED,
-                    "operationId",
-                    correlationId
+                    operationId,
+                    correlationId,
+                    paymentEndToEndId
                 )
             )
 

--- a/src/test/kotlin/it/pagopa/ecommerce/transactions/scheduler/services/TransactionInfoServiceTest.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/transactions/scheduler/services/TransactionInfoServiceTest.kt
@@ -236,7 +236,29 @@ class TransactionInfoServiceTest {
 
     @Test
     fun `Should throw error for gateway param null`() {
-        val events = TransactionInfoUtils.buildEventsList(correlationId)
+        val events =
+            TransactionInfoUtils.buildEventsList(
+                correlationId,
+                TransactionAuthorizationRequestedEvent(
+                    TRANSACTION_ID,
+                    TransactionAuthorizationRequestData(
+                        100,
+                        10,
+                        "paymentInstrumentId",
+                        "pspId2",
+                        "CP",
+                        "brokerName",
+                        "pspChannelCode",
+                        "CARDS",
+                        "pspBusinessName",
+                        false,
+                        AUTHORIZATION_REQUEST_ID,
+                        null,
+                        "paymentMethodDescription",
+                        NpgTransactionGatewayAuthorizationRequestedData()
+                    )
+                )
+            )
         val baseTransaction = reduceEvents(*events.toTypedArray())
 
         given(npgClient.getOrder(any(), any(), any()))

--- a/src/test/kotlin/it/pagopa/ecommerce/transactions/scheduler/utils/TransactionInfoUtils.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/transactions/scheduler/utils/TransactionInfoUtils.kt
@@ -21,6 +21,7 @@ class TransactionInfoUtils {
             val orderResponseDto = OrderResponseDto()
             val operationDto = OperationDto()
             operationDto.operationId = "operationId"
+            operationDto.paymentEndToEndId = "paymentEndToEndId"
             operationDto.operationType = OperationTypeDto.AUTHORIZATION
             operationDto.operationResult = OperationResultDto.FAILED
             orderResponseDto.operations = listOf(operationDto)
@@ -30,6 +31,7 @@ class TransactionInfoUtils {
             val orderResponseDto = OrderResponseDto()
             val operationDto = OperationDto()
             operationDto.operationId = "operationId"
+            operationDto.paymentEndToEndId = "paymentEndToEndId"
             operationDto.operationType = OperationTypeDto.AUTHORIZATION
             operationDto.operationResult = OperationResultDto.EXECUTED
             orderResponseDto.operations = listOf(operationDto)
@@ -39,6 +41,7 @@ class TransactionInfoUtils {
             val orderResponseDto = OrderResponseDto()
             val operationDto = OperationDto()
             operationDto.operationId = "operationId"
+            operationDto.paymentEndToEndId = "paymentEndToEndId"
             operationDto.operationType = OperationTypeDto.VOID
             operationDto.operationResult = OperationResultDto.VOIDED
             orderResponseDto.operations = listOf(operationDto)
@@ -48,6 +51,7 @@ class TransactionInfoUtils {
             val orderResponseDto = OrderResponseDto()
             val operationDto = OperationDto()
             operationDto.operationId = "operationId"
+            operationDto.paymentEndToEndId = "paymentEndToEndId"
             operationDto.operationType = OperationTypeDto.REFUND
             operationDto.operationResult = OperationResultDto.VOIDED
             orderResponseDto.operations = listOf(operationDto)
@@ -57,6 +61,7 @@ class TransactionInfoUtils {
             val orderResponseDto = OrderResponseDto()
             val operationDto = OperationDto()
             operationDto.operationId = "operationId"
+            operationDto.paymentEndToEndId = "paymentEndToEndId"
             operationDto.operationType = OperationTypeDto.REFUND
             operationDto.operationResult = OperationResultDto.EXECUTED
             orderResponseDto.operations = listOf(operationDto)

--- a/src/test/kotlin/it/pagopa/ecommerce/transactions/scheduler/utils/TransactionInfoUtils.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/transactions/scheduler/utils/TransactionInfoUtils.kt
@@ -151,75 +151,6 @@ class TransactionInfoUtils {
                 as List<TransactionEvent<Any>>)
         }
 
-        fun buildEventsList(correlationId: String): List<TransactionEvent<Any>> {
-            val transactionActivatedEvent =
-                TransactionTestUtils.transactionActivateEvent(
-                    NpgTransactionGatewayActivationData(orderId, correlationId)
-                )
-            val transactionAuthorizationRequestedEvent =
-                TransactionTestUtils.transactionAuthorizationRequestedEvent()
-
-            TransactionTestUtils.transactionAuthorizationRequestedEvent()
-
-            val transactionExpiredEvent =
-                TransactionTestUtils.transactionExpiredEvent(
-                    TransactionTestUtils.reduceEvents(
-                        transactionActivatedEvent,
-                        transactionAuthorizationRequestedEvent
-                    )
-                )
-            val transactionRefundRequestedEvent =
-                TransactionTestUtils.transactionRefundRequestedEvent(
-                    TransactionTestUtils.reduceEvents(
-                        transactionActivatedEvent,
-                        transactionAuthorizationRequestedEvent,
-                        transactionExpiredEvent
-                    ),
-                    null // N.B.: Is null when getting error while retrieving authorization data
-                    // from
-                    // gateway
-                    )
-            val transactionRefundErrorEvent =
-                TransactionTestUtils.transactionRefundErrorEvent(
-                    TransactionTestUtils.reduceEvents(
-                        transactionActivatedEvent,
-                        transactionAuthorizationRequestedEvent,
-                        transactionExpiredEvent,
-                        transactionRefundRequestedEvent
-                    )
-                )
-            val transactionRefundRetryEvent =
-                TransactionTestUtils.transactionRefundRetriedEvent(
-                    1,
-                    TransactionTestUtils.npgTransactionGatewayAuthorizationData(
-                        OperationResultDto.EXECUTED
-                    )
-                )
-            val transactionRefundedEvent =
-                TransactionTestUtils.transactionRefundedEvent(
-                    TransactionTestUtils.reduceEvents(
-                        transactionActivatedEvent,
-                        transactionAuthorizationRequestedEvent,
-                        transactionExpiredEvent,
-                        transactionRefundRequestedEvent,
-                        transactionRefundErrorEvent,
-                        transactionRefundRetryEvent
-                    ),
-                    NpgGatewayRefundData(refundOperationId)
-                )
-
-            return (listOf(
-                transactionActivatedEvent,
-                transactionAuthorizationRequestedEvent,
-                transactionExpiredEvent,
-                transactionRefundRequestedEvent,
-                transactionRefundErrorEvent,
-                transactionRefundRetryEvent,
-                transactionRefundedEvent
-            )
-                as List<TransactionEvent<Any>>)
-        }
-
         fun buildEventsList(
             correlationId: String,
             transactionAuthorizationRequestedEvent: TransactionAuthorizationRequestedEvent
@@ -228,7 +159,6 @@ class TransactionInfoUtils {
                 TransactionTestUtils.transactionActivateEvent(
                     NpgTransactionGatewayActivationData(orderId, correlationId)
                 )
-            TransactionTestUtils.transactionAuthorizationRequestedEvent()
             val transactionExpiredEvent =
                 TransactionTestUtils.transactionExpiredEvent(
                     TransactionTestUtils.reduceEvents(


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
- Add new field on DeadLetterNpgTransactionInfoDetailsData
#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
It retrieves the paymentEndToEndId field from the getOrder (NPG) call and inserts it into the TransactionInfo before writing it to the DB. This information is useful for API calls exposed by the helpdesk-service to give more information about transactions moved to DeadLetter

#### How Has This Been Tested?
Unit test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
