### PR TITLE
feat: [CHK-4356] write to transactions-view collection iff the transactions-view update enabled

### DIFF
--- a/src/main/kotlin/it/pagopa/ecommerce/transactions/scheduler/publishers/v2/TransactionExpiredEventPublisher.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/transactions/scheduler/publishers/v2/TransactionExpiredEventPublisher.kt
@@ -37,7 +37,9 @@ class TransactionExpiredEventPublisher(
     private val parallelEventToProcess: Int,
     @Value("\${azurestorage.queues.transientQueues.ttlSeconds}")
     private val transientQueueTTLSeconds: Int,
-    @Autowired private val tracingUtils: TracingUtils
+    @Autowired private val tracingUtils: TracingUtils,
+    @Value("\${transactionsview.update.enabled}")
+    private val transactionsViewUpdateEnabled: Boolean,
 ) :
     EventPublisher<TransactionExpiredEventV2, BaseTransactionV2>(
         queueAsyncClient = expiredEventQueueAsyncClient,
@@ -100,21 +102,35 @@ class TransactionExpiredEventPublisher(
         toEvent(transaction)
             .flatMap { eventStoreRepository.save(it) }
             .flatMap { event ->
-                viewRepository
-                    .findByTransactionId(transaction.transactionId.value())
-                    .cast(TransactionV2::class.java)
-                    .flatMap {
-                        it.status = newStatus
-                        viewRepository.save(it)
-                    }
-                    .flatMap { Mono.just(event) }
+                conditionallySaveTransactionView(transaction, newStatus).then(Mono.just(event))
             }
 
-    override fun toEvent(baseTrasaction: BaseTransactionV2): Mono<TransactionExpiredEventV2> =
+    /**
+     * Save the transaction in the transactions-view collection, iff the transactions-view update is
+     * enabled. Otherwise, do nothing.
+     */
+    private fun conditionallySaveTransactionView(
+        transaction: BaseTransactionV2,
+        newStatus: TransactionStatusDto
+    ): Mono<Void> =
+        if (transactionsViewUpdateEnabled) {
+            viewRepository
+                .findByTransactionId(transaction.transactionId.value())
+                .cast(TransactionV2::class.java)
+                .flatMap {
+                    it.status = newStatus
+                    viewRepository.save(it)
+                }
+                .then()
+        } else {
+            Mono.empty()
+        }
+
+    override fun toEvent(baseTransaction: BaseTransactionV2): Mono<TransactionExpiredEventV2> =
         Mono.just(
             TransactionExpiredEventV2(
-                baseTrasaction.transactionId.value(),
-                TransactionExpiredDataV2(baseTrasaction.status)
+                baseTransaction.transactionId.value(),
+                TransactionExpiredDataV2(baseTransaction.status)
             )
         )
 


### PR DESCRIPTION
Dep: #192 

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Introduce a specific check in the code in order to write to the `transactions-view` collection if and only if the `transactions-view` update is enabled on this service.

#### List of Changes
 - Introduced a specific check to write the `transactions-view` collection in the code
 - Updated tests


<!--- Describe your changes in detail -->

#### Motivation and Context

In order to have a way to set the responsibility to update the `transactions-vew` collection, we have introduced a feature flag in the form of an environment variable to write to the `transactions-view` only if we explitly set the feature flag as enabled.

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
 - tests
 - dev

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
