### PR TITLE
feat(cdc-field): [CHK-4363] add lastProcessedEventAt to transactions-view

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <maven.compiler.target>21</maven.compiler.target>
         <azure.functions.java.library.version>3.0.0</azure.functions.java.library.version>
         <spring.cloud.azure.dependencies>5.22.0</spring.cloud.azure.dependencies>
-        <pagopa-ecommerce-commons.version>3.0.0</pagopa-ecommerce-commons.version>
+        <pagopa-ecommerce-commons.version>3.0.1</pagopa-ecommerce-commons.version>
         <spotless.version>2.28.0</spotless.version>
         <jacoco.version>0.8.13</jacoco.version>
         <maven.compiler.plugin.version>3.13.0</maven.compiler.plugin.version>

--- a/src/test/kotlin/it/pagopa/ecommerce/transactions/scheduler/publishers/v2/TransactionExpiredEventPublisherTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/transactions/scheduler/publishers/v2/TransactionExpiredEventPublisherTests.kt
@@ -63,6 +63,8 @@ class TransactionExpiredEventPublisherTests {
 
     private val tracingUtils = TracingUtilsTests.getMock()
 
+    private val fixedTestTimestamp = "2024-01-01T10:00:00.000Z"
+
     @Test
     fun `Should publish all events`() {
         // preconditions
@@ -91,7 +93,9 @@ class TransactionExpiredEventPublisherTests {
             )
             .willReturn(queueAsyncClientResponse)
         given(eventStoreRepository.save(eventStoreCaptor.capture())).willAnswer {
-            Mono.just(it.arguments[0])
+            val event = it.arguments[0] as TransactionExpiredEvent
+            event.creationDate = fixedTestTimestamp
+            Mono.just(event)
         }
         given(viewRepository.findByTransactionId(org.mockito.kotlin.any())).willAnswer {
             val transaction =
@@ -181,7 +185,9 @@ class TransactionExpiredEventPublisherTests {
         sendMessageResult.messageId = "msgId"
         sendMessageResult.timeNextVisible = OffsetDateTime.now()
         given(eventStoreRepository.save(eventStoreCaptor.capture())).willAnswer {
-            Mono.just(it.arguments[0])
+            val event = it.arguments[0] as TransactionExpiredEvent
+            event.creationDate = fixedTestTimestamp
+            Mono.just(event)
         }
         given(viewRepository.findByTransactionId(org.mockito.kotlin.any())).willAnswer {
             val transaction =
@@ -290,7 +296,9 @@ class TransactionExpiredEventPublisherTests {
                 Mono.error(QueueStorageException("Error sending message to queue", null, null))
             )
         given(eventStoreRepository.save(eventStoreCaptor.capture())).willAnswer {
-            Mono.just(it.arguments[0])
+            val event = it.arguments[0] as TransactionExpiredEvent
+            event.creationDate = fixedTestTimestamp
+            Mono.just(event)
         }
         given(viewRepository.findByTransactionId(org.mockito.kotlin.any())).willAnswer {
             val transaction =
@@ -384,6 +392,7 @@ class TransactionExpiredEventPublisherTests {
             .willReturnConsecutively(
                 allEvents.map { event ->
                     if (event.transactionId != errorTransactionId.value()) {
+                        event.creationDate = fixedTestTimestamp
                         Mono.just(event)
                     } else {
                         Mono.error(MongoException("Error writing event to event store"))
@@ -505,7 +514,9 @@ class TransactionExpiredEventPublisherTests {
             )
             .willReturn(queueAsyncClientResponse)
         given(eventStoreRepository.save(eventStoreCaptor.capture())).willAnswer {
-            Mono.just(it.arguments[0])
+            val event = it.arguments[0] as TransactionExpiredEvent
+            event.creationDate = fixedTestTimestamp
+            Mono.just(event)
         }
         given(viewRepository.findByTransactionId(org.mockito.kotlin.any())).willAnswer {
             val transaction =
@@ -627,7 +638,9 @@ class TransactionExpiredEventPublisherTests {
             Mono.just(ResponseBase(null, 200, null, sendMessageResult, null))
 
         given(eventStoreRepository.save(eventStoreCaptor.capture())).willAnswer {
-            Mono.just(it.arguments[0])
+            val event = it.arguments[0] as TransactionExpiredEvent
+            event.creationDate = fixedTestTimestamp
+            Mono.just(event)
         }
         given(viewRepository.save(viewArgumentCaptor.capture())).willAnswer {
             Mono.just(it.arguments[0])
@@ -759,7 +772,9 @@ class TransactionExpiredEventPublisherTests {
             )
             .willReturn(queueAsyncClientResponse)
         given(eventStoreRepository.save(eventStoreCaptor.capture())).willAnswer {
-            Mono.just(it.arguments[0])
+            val event = it.arguments[0] as TransactionExpiredEvent
+            event.creationDate = fixedTestTimestamp
+            Mono.just(event)
         }
         given(viewRepository.findByTransactionId(org.mockito.kotlin.any())).willAnswer {
             val transaction =
@@ -942,7 +957,9 @@ class TransactionExpiredEventPublisherTests {
             )
             .willReturn(queueAsyncClientResponse)
         given(eventStoreRepository.save(eventStoreCaptor.capture())).willAnswer {
-            Mono.just(it.arguments[0])
+            val event = it.arguments[0] as TransactionExpiredEvent
+            event.creationDate = fixedTestTimestamp
+            Mono.just(event)
         }
         given(viewRepository.findByTransactionId(org.mockito.kotlin.any())).willAnswer {
             val transaction =
@@ -1057,7 +1074,9 @@ class TransactionExpiredEventPublisherTests {
             )
             .willReturn(queueAsyncClientResponse)
         given(eventStoreRepository.save(eventStoreCaptor.capture())).willAnswer {
-            Mono.just(it.arguments[0])
+            val event = it.arguments[0] as TransactionExpiredEvent
+            event.creationDate = fixedTestTimestamp
+            Mono.just(event)
         }
         given(viewRepository.findByTransactionId(org.mockito.kotlin.any())).willAnswer {
             val transaction =
@@ -1172,7 +1191,9 @@ class TransactionExpiredEventPublisherTests {
             )
             .willReturn(queueAsyncClientResponse)
         given(eventStoreRepository.save(eventStoreCaptor.capture())).willAnswer {
-            Mono.just(it.arguments[0])
+            val event = it.arguments[0] as TransactionExpiredEvent
+            event.creationDate = fixedTestTimestamp
+            Mono.just(event)
         }
         given(viewRepository.findByTransactionId(org.mockito.kotlin.any())).willAnswer {
             val transaction =
@@ -1287,7 +1308,9 @@ class TransactionExpiredEventPublisherTests {
             )
             .willReturn(queueAsyncClientResponse)
         given(eventStoreRepository.save(eventStoreCaptor.capture())).willAnswer {
-            Mono.just(it.arguments[0])
+            val event = it.arguments[0] as TransactionExpiredEvent
+            event.creationDate = fixedTestTimestamp
+            Mono.just(event)
         }
         given(viewRepository.findByTransactionId(org.mockito.kotlin.any())).willAnswer {
             val transaction =
@@ -1402,7 +1425,9 @@ class TransactionExpiredEventPublisherTests {
             )
             .willReturn(queueAsyncClientResponse)
         given(eventStoreRepository.save(eventStoreCaptor.capture())).willAnswer {
-            Mono.just(it.arguments[0])
+            val event = it.arguments[0] as TransactionExpiredEvent
+            event.creationDate = fixedTestTimestamp
+            Mono.just(event)
         }
 
         val batchExecutionTimeWindow = TimeUnit.HOURS.toMillis(1)
@@ -1464,11 +1489,18 @@ class TransactionExpiredEventPublisherTests {
         verify(viewRepository, never()).save(any())
     }
 
-    private fun baseTransactionToExpiryEvent(transaction: BaseTransaction) =
-        TransactionExpiredEvent(
-            transaction.transactionId.value(),
-            TransactionExpiredData(transaction.status)
-        )
+    private fun baseTransactionToExpiryEvent(
+        transaction: BaseTransaction,
+        creationDate: String = fixedTestTimestamp
+    ): TransactionExpiredEvent {
+        val event =
+            TransactionExpiredEvent(
+                transaction.transactionId.value(),
+                TransactionExpiredData(transaction.status)
+            )
+        event.creationDate = creationDate
+        return event
+    }
 
     private fun equalityAssertionsOnEventStore(
         expectedGeneratedEvent: TransactionExpiredEvent,
@@ -1502,6 +1534,14 @@ class TransactionExpiredEventPublisherTests {
             equalityMessage
         )
         assertEquals(expectedViewStatus, capturedValue.status, equalityMessage)
+
+        val expectedTimestamp =
+            ZonedDateTime.parse(expectedGeneratedEvent.creationDate).toInstant().toEpochMilli()
+        assertEquals(
+            expectedTimestamp,
+            capturedValue.lastProcessedEventAt,
+            "$equalityMessage - lastProcessedEventAt timestamp"
+        )
     }
 
     private fun equalityAssertionsOnSentEvent(


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
- added lastProcessedEventAt to the EXPIRED event save on transactions-view

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This change is needed so that the new field can be used for sorting events by the new ecommerce-cdc service (ref. https://github.com/pagopa/pagopa-ecommerce-cdc-service)

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- unit tests
- test after dev deploy making a transaction in a non final state expire and check that the new field has been saved to the view (see screenshot)

#### Screenshots (if appropriate):

eventstore document: 
<img width="673" height="147" alt="image" src="https://github.com/user-attachments/assets/c3aa4432-62a6-4046-99dd-0a3e1a8360af" />

transactions-view document with same timestamp (in milliseconds)
<img width="550" height="294" alt="image" src="https://github.com/user-attachments/assets/1db2bef6-e33e-4057-b0ed-a59bed5dfbf0" />

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
