### PR TITLE
chore(reactive-redis): [PIDM-853] Reactive Redis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -455,8 +455,8 @@
                 <configuration>
                     <skipCheckoutIfExists>false</skipCheckoutIfExists>
                     <connectionUrl>scm:git:https://github.com/pagopa/pagopa-ecommerce-commons.git</connectionUrl>
-                    <scmVersionType>tag</scmVersionType>
-                    <scmVersion>${pagopa-ecommerce-commons.version}</scmVersion>
+                    <scmVersionType>branch</scmVersionType>
+                    <scmVersion>PIDM-852-update-to-reactive-redis</scmVersion>
                     <goals>install -DskipTests</goals>
                 </configuration>
                 <executions>

--- a/src/main/kotlin/it/pagopa/ecommerce/transactions/scheduler/configurations/redis/EventDispatcherCommandsTemplateWrapper.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/transactions/scheduler/configurations/redis/EventDispatcherCommandsTemplateWrapper.kt
@@ -1,16 +1,16 @@
 package it.pagopa.ecommerce.transactions.scheduler.configurations.redis
 
-import it.pagopa.ecommerce.commons.redis.templatewrappers.RedisTemplateWrapper
+import it.pagopa.ecommerce.commons.redis.reactivetemplatewrappers.ReactiveRedisTemplateWrapper
 import it.pagopa.ecommerce.transactions.scheduler.streams.commands.EventDispatcherReceiverCommand
 import java.time.Duration
-import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.core.ReactiveRedisTemplate
 
 /** Redis command template wrapper, used to write events to Redis stream */
 class EventDispatcherCommandsTemplateWrapper(
-    redisTemplate: RedisTemplate<String, EventDispatcherReceiverCommand>,
+    redisTemplate: ReactiveRedisTemplate<String, EventDispatcherReceiverCommand>,
     defaultEntitiesTTL: Duration
 ) :
-    RedisTemplateWrapper<EventDispatcherReceiverCommand>(
+    ReactiveRedisTemplateWrapper<EventDispatcherReceiverCommand>(
         redisTemplate,
         "scheduler",
         defaultEntitiesTTL

--- a/src/main/kotlin/it/pagopa/ecommerce/transactions/scheduler/configurations/redis/EventDispatcherReceiverStatusTemplateWrapper.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/transactions/scheduler/configurations/redis/EventDispatcherReceiverStatusTemplateWrapper.kt
@@ -1,16 +1,16 @@
 package it.pagopa.ecommerce.transactions.scheduler.configurations.redis
 
-import it.pagopa.ecommerce.commons.redis.templatewrappers.RedisTemplateWrapper
+import it.pagopa.ecommerce.commons.redis.reactivetemplatewrappers.ReactiveRedisTemplateWrapper
 import it.pagopa.ecommerce.transactions.scheduler.repositories.redis.eventreceivers.ReceiversStatus
 import java.time.Duration
-import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.core.ReactiveRedisTemplate
 
 /** Redis template wrapper used to handle event receiver statuses */
 class EventDispatcherReceiverStatusTemplateWrapper(
-    redisTemplate: RedisTemplate<String, ReceiversStatus>,
+    redisTemplate: ReactiveRedisTemplate<String, ReceiversStatus>,
     defaultEntitiesTTL: Duration
 ) :
-    RedisTemplateWrapper<ReceiversStatus>(
+    ReactiveRedisTemplateWrapper<ReceiversStatus>(
         redisTemplate,
         "scheduler-receiver-status",
         defaultEntitiesTTL

--- a/src/main/kotlin/it/pagopa/ecommerce/transactions/scheduler/configurations/redis/RedisConfig.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/transactions/scheduler/configurations/redis/RedisConfig.kt
@@ -1,48 +1,53 @@
 package it.pagopa.ecommerce.transactions.scheduler.configurations.redis
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import it.pagopa.ecommerce.transactions.scheduler.repositories.redis.eventreceivers.ReceiversStatus
 import it.pagopa.ecommerce.transactions.scheduler.streams.commands.EventDispatcherReceiverCommand
-import java.time.Duration
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.data.redis.connection.RedisConnectionFactory
-import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory
+import org.springframework.data.redis.core.ReactiveRedisTemplate
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer
+import org.springframework.data.redis.serializer.RedisSerializationContext
 import org.springframework.data.redis.serializer.StringRedisSerializer
 
 /** Redis templates wrapper configuration */
 @Configuration
 class RedisConfig {
+    private val objectMapper: ObjectMapper = jacksonObjectMapper()
 
     @Bean
     fun eventDispatcherCommandRedisTemplateWrapper(
-        redisConnectionFactory: RedisConnectionFactory
-    ): EventDispatcherCommandsTemplateWrapper {
-        val redisTemplate = RedisTemplate<String, EventDispatcherReceiverCommand>()
-        redisTemplate.setConnectionFactory(redisConnectionFactory)
-        redisTemplate.setDefaultSerializer(StringRedisSerializer())
-        redisTemplate.afterPropertiesSet()
-        /*
-         * This redis template instance is to write events to Redis Stream through opsForStreams apis.
-         * No document is written into cache.
-         * Set TTL to 0 here will throw an error during writing operation to cache to enforce the fact that this
-         * wrapper has to be used only to write to Redis Streams
-         */
-        return EventDispatcherCommandsTemplateWrapper(redisTemplate, Duration.ZERO)
+        connectionFactory: ReactiveRedisConnectionFactory
+    ): ReactiveRedisTemplate<String, EventDispatcherReceiverCommand> {
+        val keySerializer = StringRedisSerializer()
+        val valueSerializer =
+            Jackson2JsonRedisSerializer(objectMapper, EventDispatcherReceiverCommand::class.java)
+
+        val context =
+            RedisSerializationContext.newSerializationContext<
+                    String, EventDispatcherReceiverCommand>(keySerializer)
+                .value(valueSerializer)
+                .build()
+
+        return ReactiveRedisTemplate(connectionFactory, context)
     }
 
     @Bean
     fun eventDispatcherReceiverStatusTemplateWrapper(
-        redisConnectionFactory: RedisConnectionFactory
-    ): EventDispatcherReceiverStatusTemplateWrapper {
-        val jacksonSerializer =
-            Jackson2JsonRedisSerializer(jacksonObjectMapper(), ReceiversStatus::class.java)
-        val redisTemplate = RedisTemplate<String, ReceiversStatus>()
-        redisTemplate.setConnectionFactory(redisConnectionFactory)
-        redisTemplate.keySerializer = StringRedisSerializer()
-        redisTemplate.valueSerializer = jacksonSerializer
-        redisTemplate.afterPropertiesSet()
-        return EventDispatcherReceiverStatusTemplateWrapper(redisTemplate, Duration.ofMinutes(1))
+        connectionFactory: ReactiveRedisConnectionFactory
+    ): ReactiveRedisTemplate<String, ReceiversStatus> {
+        val keySerializer = StringRedisSerializer()
+        val valueSerializer = Jackson2JsonRedisSerializer(objectMapper, ReceiversStatus::class.java)
+
+        val context =
+            RedisSerializationContext.newSerializationContext<String, ReceiversStatus>(
+                    keySerializer
+                )
+                .value(valueSerializer)
+                .build()
+
+        return ReactiveRedisTemplate(connectionFactory, context)
     }
 }

--- a/src/main/kotlin/it/pagopa/ecommerce/transactions/scheduler/controller/EventReceiversApiController.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/transactions/scheduler/controller/EventReceiversApiController.kt
@@ -28,8 +28,8 @@ class EventReceiversApiController(
     override suspend fun retrieveReceiverStatus(
         version: DeploymentVersionDto?
     ): ResponseEntity<EventReceiverStatusResponseDto> {
-        return eventReceiverService.getReceiversStatus(deploymentVersionDto = version).let {
-            ResponseEntity.ok(it)
-        }
+        val dto = eventReceiverService.getReceiversStatus(deploymentVersionDto = version)
+
+        return ResponseEntity.ok(dto)
     }
 }

--- a/src/test/kotlin/it/pagopa/ecommerce/transactions/scheduler/services/EventReceiverServiceTest.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/transactions/scheduler/services/EventReceiverServiceTest.kt
@@ -19,6 +19,8 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.mockito.kotlin.*
 import org.springframework.data.redis.connection.stream.RecordId
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class EventReceiverServiceTest {
@@ -68,7 +70,7 @@ class EventReceiverServiceTest {
                         any()
                     )
                 )
-                .willReturn(RecordId.autoGenerate())
+                .willReturn(Mono.just(RecordId.autoGenerate()))
             // test
             eventReceiverService.handleCommand(request)
             // assertions
@@ -125,7 +127,7 @@ class EventReceiverServiceTest {
                     )
             )
         given(eventDispatcherReceiverStatusTemplateWrapper.allValuesInKeySpace)
-            .willReturn(receiverStatuses.toMutableList())
+            .willReturn(Flux.fromIterable(receiverStatuses))
 
         // test
         val response = eventReceiverService.getReceiversStatus(deploymentVersionDto = null)
@@ -172,7 +174,7 @@ class EventReceiverServiceTest {
                         )
                 )
             given(eventDispatcherReceiverStatusTemplateWrapper.allValuesInKeySpace)
-                .willReturn(receiverStatuses.toMutableList())
+                .willReturn(Flux.fromIterable(receiverStatuses.toMutableList()))
 
             // test
             val response =
@@ -206,7 +208,7 @@ class EventReceiverServiceTest {
                 )
 
             given(eventDispatcherReceiverStatusTemplateWrapper.allValuesInKeySpace)
-                .willReturn(receiverStatuses.toMutableList())
+                .willReturn(Flux.fromIterable(receiverStatuses.toMutableList()))
 
             // test
             assertThrows<NoEventReceiverStatusFound> {

--- a/src/test/kotlin/it/pagopa/ecommerce/transactions/scheduler/services/EventReceiverStatusPollerTest.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/transactions/scheduler/services/EventReceiverStatusPollerTest.kt
@@ -8,6 +8,7 @@ import it.pagopa.generated.scheduler.server.model.DeploymentVersionDto
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.*
+import reactor.core.publisher.Mono
 
 class EventReceiverStatusPollerTest {
 
@@ -37,16 +38,17 @@ class EventReceiverStatusPollerTest {
 
     @Test
     fun `Should poll for status successfully saving receiver statuses`() {
-        // assertions
         val receiverStatuses =
             listOf(
                 ReceiverStatus(name = "receiver1", status = Status.UP),
                 ReceiverStatus(name = "receiver2", status = Status.DOWN)
             )
+
         given(inboundChannelAdapterLifecycleHandlerService.getAllChannelStatus())
             .willReturn(receiverStatuses)
-        doNothing().`when`(eventDispatcherReceiverStatusTemplateWrapper).save(any(), any())
-        // test
+        given(eventDispatcherReceiverStatusTemplateWrapper.save(any(), any()))
+            .willReturn(Mono.just(true))
+
         eventReceiverStatusPoller.eventReceiverStatusPoller()
         verify(eventDispatcherReceiverStatusTemplateWrapper, times(1))
             .save(


### PR DESCRIPTION
#### List of Changes

Migrated from RedisTemplate to ReactiveRedisTemplate to align with reactive programming practices.

Adjusted Redis configurations in RedisConfig.kt to support the reactive template.

Refactored RedisTemplateWrapper into ReactiveRedisTemplateWrapper to enable non-blocking operations.

Updated Redis-backed services and test classes to work with reactive types (Mono, Flux).

#### Motivation and Context

This change introduces reactive Redis operations, ensuring non-blocking behavior within the service, especially for Redis streams and value operations.

#### How Has This Been Tested?

Unit tests for Redis-related services were updated and executed using Mono and Flux to validate non-blocking functionality.

#### Screenshots (if appropriate):

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
