### PR TITLE
fix: [CHK-4840] add cache method to avoid multiple queries

### DIFF
--- a/src/main/kotlin/it/pagopa/ecommerce/transactions/scheduler/services/TransactionInfoService.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/transactions/scheduler/services/TransactionInfoService.kt
@@ -40,11 +40,13 @@ class TransactionInfoService(
 
     fun getTransactionInfoByTransactionId(transactionId: String): Mono<DeadLetterTransactionInfo> {
         val events =
-            Mono.just(transactionId).flatMapMany {
-                transactionsEventStoreRepository.findByTransactionIdOrderByCreationDateAsc(
-                    transactionId
-                )
-            }
+            Mono.just(transactionId)
+                .flatMapMany {
+                    transactionsEventStoreRepository.findByTransactionIdOrderByCreationDateAsc(
+                        transactionId
+                    )
+                }
+                .cache()
 
         return events
             .reduce(

--- a/src/main/kotlin/it/pagopa/ecommerce/transactions/scheduler/transactionanalyzer/PendingTransactionAnalyzer.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/transactions/scheduler/transactionanalyzer/PendingTransactionAnalyzer.kt
@@ -191,7 +191,8 @@ class PendingTransactionAnalyzer(
 
     private fun analyzeTransactionV1(transactionId: String): Mono<BaseTransactionV1> {
         logger.info("Analyze Transaction v1 $transactionId")
-        val events = eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(transactionId)
+        val events =
+            eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(transactionId).cache()
         return events
             .reduce(
                 EmptyTransactionV1(),
@@ -210,7 +211,8 @@ class PendingTransactionAnalyzer(
 
     private fun analyzeTransactionV2(transactionId: String): Mono<BaseTransactionV2> {
         logger.info("Analyze Transaction v2 $transactionId")
-        val events = eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(transactionId)
+        val events =
+            eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(transactionId).cache()
         return events
             .reduce(
                 EmptyTransactionV2(),


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- Added `cache` method to Flux which are subscribed multiple times to avoid useless queries

#### Motivation and Context

Cold mono causes one query to be executed per subscription, resulting in multiple find query being done for the same event processing

#### How Has This Been Tested?

- Unit test

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
