### PR TITLE
feat: [PIDM-1969] add deps submission action

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,36 @@
+name: Maven Dependency Submission
+
+# Submits the Maven dependency graph to GitHub so it can be used by
+# Dependency graph / Dependabot / security scanning.
+# This replaces GitHub's "Automatic dependency submission" (submit-maven).
+
+on:
+  push:
+  workflow_dispatch:
+
+permissions:
+  contents: write # required to submit the dependency snapshot
+
+jobs:
+  dependency-submission:
+    name: Submit Maven Dependency Graph
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # submit the dependency snapshot
+      packages: read # read pagopa-ecommerce-commons / depcheck from GitHub Packages
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Submit Dependency Snapshot
+        uses: advanced-security/maven-dependency-submission-action@b275d12641ac2d2108b2cbb7598b154ad2f2cee8 # v5.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

- add `.github/workflows/dependency-submission.yml` that submits the Maven dependency graph to GitHub on every push (mirrors the cadence of the automatic job it replaces)
- grant the workflow token `packages: read` so Maven can resolve `pagopa-ecommerce-commons` and the `depcheck` plugin from GitHub Packages
- rely on `actions/setup-java`'s auto-generated `~/.m2/settings.xml` (default server id `github`, password `${env.GITHUB_TOKEN}`) for GitHub Packages auth instead of a hand-rolled settings file
- pin actions to Node 24 versions: `actions/checkout` v6.0.3 and `actions/setup-java` v5.3.0; `advanced-security/maven-dependency-submission-action` pinned to v5.0.0

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

GitHub's automatic dependency submission (`submit-maven`) was failing because the auto-injected token has no `packages: read` permission and no Maven `settings.xml`, so it could not resolve the artifacts hosted on GitHub Packages and failed at `mvn validate`. This introduces a custom workflow that runs the submission with the required package-read permission. 

The repo-level automatic submission has been disabled to avoid duplicate runs.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- pushed to the feature branch and verified the workflow run completes with `Snapshot successfully created` and the dependency graph is submitted to GitHub
- confirmed Maven resolves the GitHub Packages artifacts using only the `setup-java`-generated `settings.xml` (no manual settings step)

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
